### PR TITLE
 Adding message properties into messageContext

### DIFF
--- a/SETUP.txt
+++ b/SETUP.txt
@@ -13,24 +13,28 @@ Tested Platform:
  
 Sample Inbound Configuration:
 
-<inboundEndpoint xmlns="http://ws.apache.org/ns/synapse" name="custom_listener" sequence="request" onError="fault"
-                     class="org.wso2.carbon.inbound.smpp.SMPPListeningConsumer" suspend="false">
+<?xml version="1.0" encoding="UTF-8"?>
+<inboundEndpoint xmlns="http://ws.apache.org/ns/synapse"
+                 name="SMPP"
+                 sequence="request"
+                 onError="fault"
+                 class="org.wso2.carbon.inbound.smpp.SMPPListeningConsumer"
+                 suspend="false">
    <parameters>
+      <parameter name="inbound.behavior">eventBased</parameter>
       <parameter name="sequential">true</parameter>
       <parameter name="coordination">true</parameter>
       <parameter name="port">2775</parameter>
-      <parameter name="host">localhost</parameter>
-      <parameter name="systemType">cp</parameter>
-      <parameter name="systemId">user1</parameter>
-      <parameter name="password">pass1</parameter>
       <parameter name="addressNpi">UNKNOWN</parameter>
+      <parameter name="host">localhost</parameter>
+      <parameter name="reconnectInterval">3000</parameter>
       <parameter name="addressTon">UNKNOWN</parameter>
+      <parameter name="systemType">CPT</parameter>
+      <parameter name="retryCount">-1</parameter>
       <parameter name="bindType">BIND_RX</parameter>
       <parameter name="addressRange">null</parameter>
-      <parameter name="enquireLinktimer">3000</parameter>
-      <parameter name="transactiontimer">200</parameter>
-      <parameter name="reconnectInterval">2000</parameter>
-      <parameter name="retryCount">10</parameter>
+      <parameter name="systemId">esb1</parameter>
+      <parameter name="password">esb123</parameter>
       <parameter name="exponentialFactor">5</parameter>
       <parameter name="maximumBackoffTime">10000</parameter>
    </parameters>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,8 @@ Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
                             com.nurkiewicz.asyncretry.*,
                             org.apache.synapse.*,
                             org.apache.commons.*,
+                            org.apache.axis2.*,
+                            org.apache.axiom.*,
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
@@ -412,21 +412,21 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
         AutoCloseInputStream in = new AutoCloseInputStream(new ByteArrayInputStream(strMessage.getBytes()));
 
         try {
-            if(logger.isDebugEnabled()) {
+            if (logger.isDebugEnabled()) {
                 logger.debug("Processed Custom inbound EP Message of Content-type : " + contentType + " for " + name);
             }
 
             org.apache.axis2.context.MessageContext axis2MsgCtx = ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
             Object builder;
-            if(StringUtils.isEmpty(contentType)) {
+            if (StringUtils.isEmpty(contentType)) {
                 logger.debug("No content type specified. Using SOAP builder for " + name);
                 builder = new SOAPBuilder();
             } else {
                 int index = contentType.indexOf(59);
-                String type = index > 0?contentType.substring(0, index):contentType;
+                String type = index > 0 ? contentType.substring(0, index) : contentType;
                 builder = BuilderUtil.getBuilderFromSelector(type, axis2MsgCtx);
-                if(builder == null) {
-                    if(logger.isDebugEnabled()) {
+                if (builder == null) {
+                    if (logger.isDebugEnabled()) {
                         logger.debug("No message builder found for type \'" + type + "\'. Falling back to SOAP." + name);
                     }
 
@@ -434,25 +434,25 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
                 }
             }
 
-            OMElement documentElement = ((Builder)builder).processDocument(in, contentType, axis2MsgCtx);
+            OMElement documentElement = ((Builder) builder).processDocument(in, contentType, axis2MsgCtx);
             msgCtx.setEnvelope(TransportUtils.createSOAPEnvelope(documentElement));
-            if(this.injectingSeq == null || "".equals(this.injectingSeq)) {
+            if (this.injectingSeq == null || "".equals(this.injectingSeq)) {
                 logger.error("Sequence name not specified. Sequence : " + this.injectingSeq);
                 return false;
             }
 
-            SequenceMediator seq = (SequenceMediator)this.synapseEnvironment.getSynapseConfiguration().getSequence(this.injectingSeq);
-            if(seq != null) {
-                if(logger.isDebugEnabled()) {
+            SequenceMediator seq = (SequenceMediator) this.synapseEnvironment.getSynapseConfiguration().getSequence(this.injectingSeq);
+            if (seq != null) {
+                if (logger.isDebugEnabled()) {
                     logger.debug("injecting message to sequence : " + this.injectingSeq);
                 }
 
                 seq.setErrorHandler(this.onErrorSeq);
-                if(!seq.isInitialized()) {
+                if (!seq.isInitialized()) {
                     seq.init(this.synapseEnvironment);
                 }
 
-                if(!this.synapseEnvironment.injectInbound(msgCtx, seq, this.sequential)) {
+                if (!this.synapseEnvironment.injectInbound(msgCtx, seq, this.sequential)) {
                     return false;
                 }
             } else {

--- a/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
@@ -23,11 +23,21 @@ import com.nurkiewicz.asyncretry.AsyncRetryExecutor;
 import com.nurkiewicz.asyncretry.RetryContext;
 import com.nurkiewicz.asyncretry.RetryExecutor;
 import com.nurkiewicz.asyncretry.function.RetryRunnable;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.UUIDGenerator;
+import org.apache.axis2.builder.Builder;
+import org.apache.axis2.builder.BuilderUtil;
+import org.apache.axis2.builder.SOAPBuilder;
+import org.apache.axis2.transport.TransportUtils;
+import org.apache.commons.io.input.AutoCloseInputStream;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.base.SequenceMediator;
 import org.jsmpp.bean.AlertNotification;
 import org.jsmpp.bean.BindType;
 import org.jsmpp.bean.DataSm;
@@ -42,8 +52,10 @@ import org.jsmpp.session.MessageReceiverListener;
 import org.jsmpp.session.SMPPSession;
 import org.jsmpp.session.Session;
 import org.jsmpp.session.SessionStateListener;
+import org.jsmpp.util.InvalidDeliveryReceiptException;
 import org.wso2.carbon.inbound.endpoint.protocol.generic.GenericEventBasedConsumer;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.util.Properties;
@@ -136,6 +148,7 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
      * An object that executes submitted Runnable tasks.
      */
     private RetryExecutor executor;
+    private MessageContext msgCtx;
 
     public SMPPListeningConsumer(Properties smppProperties, String name,
                                  SynapseEnvironment synapseEnvironment, String injectingSeq,
@@ -350,6 +363,30 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
     private class MessageReceiverListenerImpl implements MessageReceiverListener {
         public void onAcceptDeliverSm(DeliverSm deliverSm) throws ProcessRequestException {
             // inject short message into the sequence.
+            msgCtx = createMessageContext();
+            msgCtx.setProperty("MessageId", deliverSm.getSmDefaultMsgId());
+            msgCtx.setProperty("SourceAddress", deliverSm.getSourceAddr());
+            msgCtx.setProperty("DestiationAddress", deliverSm.getDestAddress());
+            msgCtx.setProperty("DataCoding", deliverSm.getDataCoding());
+            msgCtx.setProperty("DestinationAddressNPI", deliverSm.getDestAddrNpi());
+            msgCtx.setProperty("DestinationAddressTON", deliverSm.getDestAddrTon());
+            msgCtx.setProperty("ESMClass", deliverSm.getEsmClass());
+            msgCtx.setProperty("PriorityFlag", deliverSm.getPriorityFlag());
+            msgCtx.setProperty("ProtocolId", deliverSm.getProtocolId());
+            msgCtx.setProperty("RegisteredDelivery", deliverSm.getRegisteredDelivery());
+            msgCtx.setProperty("ReplaceIfPresentFlag", deliverSm.getReplaceIfPresent());
+            msgCtx.setProperty("ScheduleDeliveryTime", deliverSm.getScheduleDeliveryTime());
+            msgCtx.setProperty("SequenceNumber", deliverSm.getSequenceNumber());
+            msgCtx.setProperty("ServiceType", deliverSm.getServiceType());
+            msgCtx.setProperty("SourceAddressNPI", deliverSm.getSourceAddrNpi());
+            msgCtx.setProperty("SourceAddressTON", deliverSm.getSourceAddrTon());
+            msgCtx.setProperty("ValidityPeriod", deliverSm.getValidityPeriod());
+
+            try {
+                msgCtx.setProperty("ShortMessageAsDeliveryReceipt", deliverSm.getShortMessageAsDeliveryReceipt());
+            } catch (InvalidDeliveryReceiptException e) {
+                logger.error("InvalidDeliveryReceipt");
+            }
             injectMessage(new String(deliverSm.getShortMessage()), SMPPConstants.CONTENT_TYPE);
         }
 
@@ -365,5 +402,77 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
             }
             return null;
         }
+    }
+
+    /**
+     * Inject the message into the sequence.
+     */
+    @Override
+    protected boolean injectMessage(String strMessage, String contentType) {
+        AutoCloseInputStream in = new AutoCloseInputStream(new ByteArrayInputStream(strMessage.getBytes()));
+
+        try {
+            if(logger.isDebugEnabled()) {
+                logger.debug("Processed Custom inbound EP Message of Content-type : " + contentType + " for " + name);
+            }
+
+            org.apache.axis2.context.MessageContext axis2MsgCtx = ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
+            Object builder;
+            if(StringUtils.isEmpty(contentType)) {
+                logger.debug("No content type specified. Using SOAP builder for " + name);
+                builder = new SOAPBuilder();
+            } else {
+                int index = contentType.indexOf(59);
+                String type = index > 0?contentType.substring(0, index):contentType;
+                builder = BuilderUtil.getBuilderFromSelector(type, axis2MsgCtx);
+                if(builder == null) {
+                    if(logger.isDebugEnabled()) {
+                        logger.debug("No message builder found for type \'" + type + "\'. Falling back to SOAP." + name);
+                    }
+
+                    builder = new SOAPBuilder();
+                }
+            }
+
+            OMElement documentElement = ((Builder)builder).processDocument(in, contentType, axis2MsgCtx);
+            msgCtx.setEnvelope(TransportUtils.createSOAPEnvelope(documentElement));
+            if(this.injectingSeq == null || "".equals(this.injectingSeq)) {
+                logger.error("Sequence name not specified. Sequence : " + this.injectingSeq);
+                return false;
+            }
+
+            SequenceMediator seq = (SequenceMediator)this.synapseEnvironment.getSynapseConfiguration().getSequence(this.injectingSeq);
+            if(seq != null) {
+                if(logger.isDebugEnabled()) {
+                    logger.debug("injecting message to sequence : " + this.injectingSeq);
+                }
+
+                seq.setErrorHandler(this.onErrorSeq);
+                if(!seq.isInitialized()) {
+                    seq.init(this.synapseEnvironment);
+                }
+
+                if(!this.synapseEnvironment.injectInbound(msgCtx, seq, this.sequential)) {
+                    return false;
+                }
+            } else {
+                logger.error("Sequence: " + this.injectingSeq + " not found" + name);
+            }
+        } catch (Exception e) {
+            throw new SynapseException("Error while processing the Amazon SQS Message ", e);
+        }
+
+        return true;
+    }
+
+    /**
+     * Create the message context.
+     */
+    private MessageContext createMessageContext() {
+        MessageContext msgCtx = this.synapseEnvironment.createMessageContext();
+        org.apache.axis2.context.MessageContext axis2MsgCtx = ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
+        axis2MsgCtx.setServerSide(true);
+        axis2MsgCtx.setMessageID(UUIDGenerator.getUUID());
+        return msgCtx;
     }
 }

--- a/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
@@ -148,7 +148,6 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
      * An object that executes submitted Runnable tasks.
      */
     private RetryExecutor executor;
-    private MessageContext msgCtx;
 
     public SMPPListeningConsumer(Properties smppProperties, String name,
                                  SynapseEnvironment synapseEnvironment, String injectingSeq,
@@ -363,31 +362,32 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
     private class MessageReceiverListenerImpl implements MessageReceiverListener {
         public void onAcceptDeliverSm(DeliverSm deliverSm) throws ProcessRequestException {
             // inject short message into the sequence.
+            MessageContext msgCtx;
             msgCtx = createMessageContext();
-            msgCtx.setProperty("MessageId", deliverSm.getSmDefaultMsgId());
-            msgCtx.setProperty("SourceAddress", deliverSm.getSourceAddr());
-            msgCtx.setProperty("DestiationAddress", deliverSm.getDestAddress());
-            msgCtx.setProperty("DataCoding", deliverSm.getDataCoding());
-            msgCtx.setProperty("DestinationAddressNPI", deliverSm.getDestAddrNpi());
-            msgCtx.setProperty("DestinationAddressTON", deliverSm.getDestAddrTon());
-            msgCtx.setProperty("ESMClass", deliverSm.getEsmClass());
-            msgCtx.setProperty("PriorityFlag", deliverSm.getPriorityFlag());
-            msgCtx.setProperty("ProtocolId", deliverSm.getProtocolId());
-            msgCtx.setProperty("RegisteredDelivery", deliverSm.getRegisteredDelivery());
-            msgCtx.setProperty("ReplaceIfPresentFlag", deliverSm.getReplaceIfPresent());
-            msgCtx.setProperty("ScheduleDeliveryTime", deliverSm.getScheduleDeliveryTime());
-            msgCtx.setProperty("SequenceNumber", deliverSm.getSequenceNumber());
-            msgCtx.setProperty("ServiceType", deliverSm.getServiceType());
-            msgCtx.setProperty("SourceAddressNPI", deliverSm.getSourceAddrNpi());
-            msgCtx.setProperty("SourceAddressTON", deliverSm.getSourceAddrTon());
-            msgCtx.setProperty("ValidityPeriod", deliverSm.getValidityPeriod());
+            msgCtx.setProperty("SMPP_MessageId", deliverSm.getSmDefaultMsgId());
+            msgCtx.setProperty("SMPP_SourceAddress", deliverSm.getSourceAddr());
+            msgCtx.setProperty("SMPP_DestiationAddress", deliverSm.getDestAddress());
+            msgCtx.setProperty("SMPP_DataCoding", deliverSm.getDataCoding());
+            msgCtx.setProperty("SMPP_DestinationAddressNPI", deliverSm.getDestAddrNpi());
+            msgCtx.setProperty("SMPP_DestinationAddressTON", deliverSm.getDestAddrTon());
+            msgCtx.setProperty("SMPP_ESMClass", deliverSm.getEsmClass());
+            msgCtx.setProperty("SMPP_PriorityFlag", deliverSm.getPriorityFlag());
+            msgCtx.setProperty("SMPP_ProtocolId", deliverSm.getProtocolId());
+            msgCtx.setProperty("SMPP_RegisteredDelivery", deliverSm.getRegisteredDelivery());
+            msgCtx.setProperty("SMPP_ReplaceIfPresentFlag", deliverSm.getReplaceIfPresent());
+            msgCtx.setProperty("SMPP_ScheduleDeliveryTime", deliverSm.getScheduleDeliveryTime());
+            msgCtx.setProperty("SMPP_SequenceNumber", deliverSm.getSequenceNumber());
+            msgCtx.setProperty("SMPP_ServiceType", deliverSm.getServiceType());
+            msgCtx.setProperty("SMPP_SourceAddressNPI", deliverSm.getSourceAddrNpi());
+            msgCtx.setProperty("SMPP_SourceAddressTON", deliverSm.getSourceAddrTon());
+            msgCtx.setProperty("SMPP_ValidityPeriod", deliverSm.getValidityPeriod());
 
             try {
                 msgCtx.setProperty("ShortMessageAsDeliveryReceipt", deliverSm.getShortMessageAsDeliveryReceipt());
             } catch (InvalidDeliveryReceiptException e) {
                 logger.error("InvalidDeliveryReceipt");
             }
-            injectMessage(new String(deliverSm.getShortMessage()), SMPPConstants.CONTENT_TYPE);
+            injectMessage(new String(deliverSm.getShortMessage()), SMPPConstants.CONTENT_TYPE, msgCtx);
         }
 
         public void onAcceptAlertNotification(AlertNotification alertNotification) {
@@ -407,8 +407,7 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
     /**
      * Inject the message into the sequence.
      */
-    @Override
-    protected boolean injectMessage(String strMessage, String contentType) {
+    private boolean injectMessage(String strMessage, String contentType, MessageContext msgCtx) {
         AutoCloseInputStream in = new AutoCloseInputStream(new ByteArrayInputStream(strMessage.getBytes()));
 
         try {


### PR DESCRIPTION
## Purpose
Adding SMPP Message Properties into MessageContext

## Goals
Get SMPP Message Properties such as MessageId, SourceAddress, DestiationAddress, DataCoding, DestinationAddressNPI, DestinationAddressTON, ESMClass, PriorityFlag, ProtocolId, RegisteredDelivery, ReplaceIfPresentFlag, ReplaceIfPresentFlag, ScheduleDeliveryTime, SequenceNumber, ServiceType, SourceAddressNPI, SourceAddressTON, ValidityPeriod from messageContext 

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK versions - 1.8
Operating systems - Ubuntu
 
## Learning
Learned how to add properties to message context