### PR TITLE
Add activate/deactivate functionality for SMPP inbound endpoint

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
@@ -148,6 +148,10 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
      * An object that executes submitted Runnable tasks.
      */
     private RetryExecutor executor;
+    /**
+     *  The flag serves as a coordination mechanism to prevent race conditions during the shutdown process.
+     */
+    private volatile boolean isShuttingDown = false;
 
     public SMPPListeningConsumer(Properties smppProperties, String name,
                                  SynapseEnvironment synapseEnvironment, String injectingSeq,
@@ -315,18 +319,31 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
      * Reconnect session after specified interval.
      */
     private void reconnect() {
-        final ListenableFuture future = executor.doWithRetry(new RetryRunnable() {
-            @Override
-            public void run(RetryContext retryContext) throws Exception {
-                newSession();
-            }
-        });
+        if (isShuttingDown || scheduler == null || scheduler.isShutdown()) {
+            return;
+        }
+
+        try {
+            final ListenableFuture future = executor.doWithRetry(new RetryRunnable() {
+                @Override
+                public void run(RetryContext retryContext) throws Exception {
+                    if (isShuttingDown) {
+                        throw new InterruptedException("Shutdown requested");
+                    }
+                    newSession();
+                }
+            });
+        } catch (Exception e) {
+            logger.error("Failed to schedule reconnection for " + name, e);
+        }
     }
 
     /**
      * Close the connection with the SMSC and stop all the threads.
      */
     public void destroy() {
+        isShuttingDown = true;
+
         if (session != null) {
             session.unbindAndClose();
             if (logger.isDebugEnabled()) {
@@ -341,6 +358,17 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
         }
     }
 
+    public void resume() {
+        isShuttingDown = false;
+
+        try {
+            session = newSession();
+        } catch (IOException e) {
+            reconnect();
+            throw new SynapseException("Error while getting the SMPP session", e);
+        }
+    }
+
     /**
      * This class will receive the notification from {@link SMPPSession} for the
      * state changes. It will schedule to re-initialize session.
@@ -348,6 +376,10 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
     private class SessionStateListenerImpl implements SessionStateListener {
         @Override
         public void onStateChange(SessionState sessionState, SessionState sessionState1, Object o) {
+            if (isShuttingDown) {
+                return;
+            }
+
             if (sessionState.equals(SessionState.CLOSED)) {
                 logger.info("Session closed for " + name);
                 reconnect();

--- a/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
@@ -342,6 +342,8 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
      * Close the connection with the SMSC and stop all the threads.
      */
     public void destroy() {
+        isShuttingDown = true;
+
         if (session != null) {
             session.unbindAndClose();
             if (logger.isDebugEnabled()) {
@@ -368,8 +370,7 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
     }
 
     public void pause() {
-        isShuttingDown = true;
-        destroy();
+        logger.info("Pause operation called for inbound consumer: " + name);
     }
 
     /**

--- a/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
@@ -342,8 +342,6 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
      * Close the connection with the SMSC and stop all the threads.
      */
     public void destroy() {
-        isShuttingDown = true;
-
         if (session != null) {
             session.unbindAndClose();
             if (logger.isDebugEnabled()) {
@@ -365,8 +363,13 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
             session = newSession();
         } catch (IOException e) {
             reconnect();
-            throw new SynapseException("Error while getting the SMPP session", e);
+            throw new SynapseException("Error while getting the SMPP session in resuming operation", e);
         }
+    }
+
+    public void pause() {
+        isShuttingDown = true;
+        destroy();
     }
 
     /**

--- a/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/smpp/SMPPListeningConsumer.java
@@ -320,6 +320,9 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
      */
     private void reconnect() {
         if (isShuttingDown || scheduler == null || scheduler.isShutdown()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Skipping reconnect for [" + name + "] because scheduler is in shutdown state.");
+            }
             return;
         }
 
@@ -359,6 +362,7 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
     }
 
     public void resume() {
+        logger.info("Resume operation called for inbound consumer: " + name);
         isShuttingDown = false;
 
         try {
@@ -381,6 +385,9 @@ public class SMPPListeningConsumer extends GenericEventBasedConsumer {
         @Override
         public void onStateChange(SessionState sessionState, SessionState sessionState1, Object o) {
             if (isShuttingDown) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Skipping session state change handling for [" + name + "] because shutdown is in progress.");
+                }
                 return;
             }
 

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -63,18 +63,6 @@
               "enableCondition": [{"generateSequences":false}],
               "helpTip": "Error sequence to invoke on fault"
             }
-          },
-          {
-            "type": "attribute",
-            "value": {
-              "name": "suspend",
-              "displayName": "Suspend Inbound",
-              "inputType": "checkbox",
-              "defaultValue": false,
-              "hidden": true,
-              "required": "false",
-              "helpTip": "Suspend Inbound"
-            }
           }
         ]
       }
@@ -116,6 +104,18 @@
               "defaultValue": true,
               "required": "false",
               "helpTip": "In a clustered setup, this will run the inbound only in a single worker node."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "suspend",
+              "displayName": "Suspend Inbound",
+              "inputType": "checkbox",
+              "defaultValue": false,
+              "hidden": false,
+              "required": "false",
+              "helpTip": "Enable this option to suspend the inbound endpoint immediately after deployment."
             }
           }
         ]


### PR DESCRIPTION
## Purpose
> -  Add activate/deactivate functionality for SMPP inbound endpoint.
> - Expose suspend property

> Related PRs : https://github.com/wso2/product-micro-integrator/pull/4320

## Additional Implementation Details

Introduced the isShuttingDown volatile flag to prevent race conditions and ensure graceful shutdown of the SMPP listening consumer.

#### Problem
The SMPP consumer was experiencing race conditions during shutdown where:

- Reconnection attempts could be scheduled even after destroy() was called
- Session state listeners might trigger reconnections during shutdown
- Scheduler and session cleanup could happen concurrently with new connection attempts
- No coordination mechanism existed between shutdown and ongoing operations


#### Solution
Added a volatile boolean isShuttingDown flag that serves as a coordination mechanism: